### PR TITLE
Fix #11: proper paddings that supplements to full block size backport to v2.0.0

### DIFF
--- a/src/ACryptoHashNet.UnitTests/MD/MD5Tests.cs
+++ b/src/ACryptoHashNet.UnitTests/MD/MD5Tests.cs
@@ -21,6 +21,23 @@ namespace acryptohashnet.UnitTests
         {
             var actual = new MD5().ComputeHash(Encoding.UTF8.GetBytes(input)).ToHexString();
             Assert.That(actual, Is.EqualTo(expected));
-        }        
+        }
+
+        [Test]
+        public void ValidateWithSystemCryptography()
+        {
+            var systemImpl = System.Security.Cryptography.MD5.Create();
+            var acryptohashnetImpl = new MD5();
+
+            for (var ii = 0; ii < 1024; ii += 1)
+            {
+                var input = new string('a', ii);
+
+                var expected = systemImpl.ComputeHash(Encoding.UTF8.GetBytes(input)).ToHexString();
+                var actual = acryptohashnetImpl.ComputeHash(Encoding.UTF8.GetBytes(input)).ToHexString();
+
+                Assert.That(actual, Is.EqualTo(expected));
+            }
+        }
     }
 }

--- a/src/ACryptoHashNet.UnitTests/MD/MDFamilyTestCases.cs
+++ b/src/ACryptoHashNet.UnitTests/MD/MDFamilyTestCases.cs
@@ -110,7 +110,23 @@ namespace acryptohashnet.UnitTests
                     Md2 = "58bacf68f1f8ed5a3515ae0607b3b511",
                     Md4 = "50385e2a1f0b9869040a289eff3abff2",
                     Md5 = "43696c3abe0610e776cde9bf4c052421",
-                }
+                },
+
+                new HashTestCase
+                {
+                    Input = new ('A', 56),
+                    Md2 = "2d416b30f66eebcecccee3072aba0066",
+                    Md4 = "2eae267be1bd32ff073b50f7b654aed2",
+                    Md5 = "a2f3e2024931bd470555002aa5ccc010",
+                },
+
+                new HashTestCase
+                {
+                    Input = new string('A', 120),
+                    Md2 = "498b1c1738973ca0256868c109e7f770",
+                    Md4 = "f395d199ef36203ccb40e4cf19e6b5f9",
+                    Md5 = "2fc9840470860d0d8e67a2207d15c4c9",
+                },
             };
         }
 

--- a/src/ACryptoHashNet.UnitTests/SHA/SHA1Tests.cs
+++ b/src/ACryptoHashNet.UnitTests/SHA/SHA1Tests.cs
@@ -15,6 +15,23 @@ namespace acryptohashnet.UnitTests
             Assert.That(actual, Is.EqualTo(expected));
         }
 
+        [Test]
+        public void ValidateWithSystemCryptography()
+        {
+            var systemImpl = System.Security.Cryptography.SHA1.Create();
+            var acryptohashnetImpl = new SHA1();
+
+            for (var ii = 0; ii < 1024; ii += 1)
+            {
+                var input = new string('a', ii);
+
+                var expected = systemImpl.ComputeHash(Encoding.UTF8.GetBytes(input)).ToHexString();
+                var actual = acryptohashnetImpl.ComputeHash(Encoding.UTF8.GetBytes(input)).ToHexString();
+
+                Assert.That(actual, Is.EqualTo(expected));
+            }
+        }
+
         public static IEnumerable<object[]> TestCases
         {
             get

--- a/src/ACryptoHashNet.UnitTests/SHA/SHA256Tests.cs
+++ b/src/ACryptoHashNet.UnitTests/SHA/SHA256Tests.cs
@@ -15,6 +15,23 @@ namespace acryptohashnet.UnitTests
             Assert.That(actual, Is.EqualTo(expected));
         }
 
+        [Test]
+        public void Sha256_ValidateWithSystemCryptography()
+        {
+            var systemImpl = System.Security.Cryptography.SHA256.Create();
+            var acryptohashnetImpl = new SHA256();
+
+            for (var ii = 0; ii < 1024; ii += 1)
+            {
+                var input = new string('a', ii);
+
+                var expected = systemImpl.ComputeHash(Encoding.UTF8.GetBytes(input)).ToHexString();
+                var actual = acryptohashnetImpl.ComputeHash(Encoding.UTF8.GetBytes(input)).ToHexString();
+
+                Assert.That(actual, Is.EqualTo(expected));
+            }
+        }
+
         public static IEnumerable<object[]> TestCases
         {
             get

--- a/src/ACryptoHashNet.UnitTests/SHA/SHA384Tests.cs
+++ b/src/ACryptoHashNet.UnitTests/SHA/SHA384Tests.cs
@@ -15,6 +15,23 @@ namespace acryptohashnet.UnitTests
             Assert.That(actual, Is.EqualTo(expected));
         }
 
+        [Test]
+        public void Sha2_384_ValidateWithSystemCryptography()
+        {
+            var systemImpl = System.Security.Cryptography.SHA384.Create();
+            var acryptohashnetImpl = new SHA384();
+
+            for (var ii = 0; ii < 1024; ii += 1)
+            {
+                var input = new string('a', ii);
+
+                var expected = systemImpl.ComputeHash(Encoding.UTF8.GetBytes(input)).ToHexString();
+                var actual = acryptohashnetImpl.ComputeHash(Encoding.UTF8.GetBytes(input)).ToHexString();
+
+                Assert.That(actual, Is.EqualTo(expected));
+            }
+        }
+
         public static IEnumerable<object[]> TestCases
         {
             get

--- a/src/ACryptoHashNet.UnitTests/SHA/SHA512Tests.cs
+++ b/src/ACryptoHashNet.UnitTests/SHA/SHA512Tests.cs
@@ -15,6 +15,23 @@ namespace acryptohashnet.UnitTests
             Assert.That(actual, Is.EqualTo(expected));
         }
 
+        [Test]
+        public void Sha512_ValidateWithSystemCryptography()
+        {
+            var systemImpl = System.Security.Cryptography.SHA512.Create();
+            var acryptohashnetImpl = new SHA512();
+
+            for (var ii = 0; ii < 1024; ii += 1)
+            {
+                var input = new string('a', ii);
+
+                var expected = systemImpl.ComputeHash(Encoding.UTF8.GetBytes(input)).ToHexString();
+                var actual = acryptohashnetImpl.ComputeHash(Encoding.UTF8.GetBytes(input)).ToHexString();
+
+                Assert.That(actual, Is.EqualTo(expected));
+            }
+        }
+
         public static IEnumerable<object[]> TestCases
         {
             get

--- a/src/ACryptoHashNet.UnitTests/SHA/SHAFamilyTestCases.cs
+++ b/src/ACryptoHashNet.UnitTests/SHA/SHAFamilyTestCases.cs
@@ -136,6 +136,26 @@ namespace acryptohashnet.UnitTests
                     Sha256 = "4d25fccf8752ce470a58cd21d90939b7eb25f3fa418dd2da4c38288ea561e600",
                     Sha384 = "69cc75b95280bdd9e154e743903e37b1205aa382e92e051b1f48a6db9d0203f8a17c1762d46887037275606932d3381e",
                     Sha512 = "23450737795d2f6a13aa61adcca0df5eef6df8d8db2b42cd2ca8f783734217a73e9cabc3c9b8a8602f8aeaeb34562b6b1286846060f9809b90286b3555751f09"
+                },
+
+                new HashTestCase
+                {
+                    Input = new string('A', 56),
+                    Sha0 = "7ed65d395cfede495043e882d1a4d5ffe4b90e0f",
+                    Sha1 = "6b45e3cf1eb3324b9fd4df3b83d89c4c2c4ca896",
+                    Sha256 = "6ea719cefa4b31862035a7fa606b7cc3602f46231117d135cc7119b3c1412314",
+                    Sha384 = "2aef2e21b372d018fb7d17ecdc85660eda2e19d7a2663238116d1ccd8e831efb9f2c11f0d9221f26b931255e8171442c",
+                    Sha512 = "80b696886087d1e05a32df1e90409adcb8dec7d46ef81a727976572d8c07d07429b3ba4c3a55fdeb00ebed2d6c3987726e81aebbadb64f1e898a66fdcd379d9a",
+                },
+
+                new HashTestCase
+                {
+                    Input = new string('A', 112),
+                    Sha0 = "55c4ab1b66ab2fd74553fff03e2d079bafd78ee8",
+                    Sha1 = "2760153e60cb7bc96eb59a04ed2db5de4a94edb2",
+                    Sha256 = "64bdc48c731313c7b37c1f1d13d6265ac7a2604ff630b50f591a86e610cb3005",
+                    Sha384 = "c13b89e0caf1bf5b1d7c9aca86418c38e2551367464dad217aef1aff3529a4595fae593668a269bd9592ae2710ab3d77",
+                    Sha512 = "1a008b0480a4eb64d292db671d4f43f46fc57e077b72ad3ec0a3b0b63b320357a11418ea916038e9b659ccf39ae574ef8a8f683f1eff954788591c13022fcd81",
                 }
             };
         }

--- a/src/ACryptoHashNet/BlockHashAlgorithm.cs
+++ b/src/ACryptoHashNet/BlockHashAlgorithm.cs
@@ -143,7 +143,7 @@ namespace acryptohashnet
 
         private byte[] GenerateOneZeroFillAnd8BytesMessageLengthLittleEndianPadding(ReadOnlySpan<byte> lastBlock, BigInteger messageLength)
         {
-            var paddingBlocks = lastBlock.Length + 8 > BlockSizeValue ? 2 : 1;
+            var paddingBlocks = lastBlock.Length + 8 >= BlockSizeValue ? 2 : 1;
             var padding = new byte[paddingBlocks * BlockSizeValue];
 
             lastBlock.CopyTo(padding);
@@ -169,7 +169,7 @@ namespace acryptohashnet
 
         private byte[] GenerateOneZeroFillAnd8BytesMessageLengthBigEndianPadding(ReadOnlySpan<byte> lastBlock, BigInteger messageLength)
         {
-            var paddingBlocks = lastBlock.Length + 8 > BlockSizeValue ? 2 : 1;
+            var paddingBlocks = lastBlock.Length + 8 >= BlockSizeValue ? 2 : 1;
             var padding = new byte[paddingBlocks * BlockSizeValue];
 
             lastBlock.CopyTo(padding);
@@ -195,7 +195,7 @@ namespace acryptohashnet
 
         private byte[] GenerateOneZeroFillAnd16BytesMessageLengthBigEndianPadding(ReadOnlySpan<byte> lastBlock, BigInteger messageLength)
         {
-            var paddingBlocks = lastBlock.Length + 16 > BlockSizeValue ? 2 : 1;
+            var paddingBlocks = lastBlock.Length + 16 >= BlockSizeValue ? 2 : 1;
             var padding = new byte[paddingBlocks * BlockSizeValue];
 
             lastBlock.CopyTo(padding);


### PR DESCRIPTION
Backport of #12 

>padding calculation was refactored in v3 and had a hidden bug with improper padding in case of specific lengths that almost supplements to blocksize minus 8 bytes (64 - 8 = 56 for md4/md5/sha2_256/sha2_512, 128 - 16 = 112 for sha2_384/sha2_512).
affects md4/md5/sha0/sha1/sha2/sha3.